### PR TITLE
Fixed the section where null dereference could occur.

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
@@ -65,12 +65,27 @@ bool extractPackageNameFromPath(const std::filesystem::path& path, std::string& 
       auto is_open = package_xml_file.LoadFile((sub_path / "package.xml").string().c_str());
       if (is_open == tinyxml2::XML_SUCCESS)
       {
-        auto name_potential =
-            package_xml_file.FirstChildElement("package")->FirstChildElement("name")->FirstChild()->ToText()->Value();
-        if (name_potential)
+        auto pkg = package_xml_file.FirstChildElement("package");
+        if (pkg)
         {
-          // Change package name if we have non-empty potential, else it defaults
-          package_name = name_potential;
+          auto name_elem = pkg->FirstChildElement("name");
+          if (name_elem)
+          {
+            auto name_child = name_elem->FirstChild();
+            if (name_child)
+            {
+              auto xml_text = name_child->ToText();
+              if (xml_text)
+              {
+                auto name_potential = xml_text->Value();
+                if (name_potential)
+                {
+                  // Change package name if we have non-empty potential, else it defaults
+                  package_name = name_potential;
+                }
+              }
+            }
+          }
         }
       }
       return true;

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/default_collisions_widget.cpp
@@ -426,6 +426,11 @@ void DefaultCollisionsWidget::hideSections()
     list << clicked_section_;
   }
 
+  if (!header)
+  {
+    return;
+  }
+
   for (auto index : list)
     header->setSectionHidden(index, true);
 }
@@ -454,6 +459,11 @@ void DefaultCollisionsWidget::hideOtherSections()
   {
     list.clear();
     list << clicked_section_;
+  }
+
+  if (!header)
+  {
+    return;
   }
 
   // first hide all sections


### PR DESCRIPTION
### Description

Fixed section where there was a possibility of a null reference. TODO moveitのリポジトリのissueの番号を記載する
Added a null check before the reference.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
